### PR TITLE
Specify the default container image registry docker.io

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM docker.io/ubuntu:22.04
 
 # Install node.js, Caddy as proxy server, and java.
 RUN apt-get update && \

--- a/devenv/docker-compose.yml
+++ b/devenv/docker-compose.yml
@@ -2,7 +2,7 @@
 version: "3.0"
 services:
   gstore:
-    image: dbpedia/gstore:dev #dbpedia/gstore:dev
+    image: docker.io/dbpedia/gstore:dev
     container_name: devenv_gstore
     environment: 
       STORAGE_USER: "dba"
@@ -15,7 +15,7 @@ services:
       - ./data/gstore/git:/gstore/git
       - ./data/gstore/logs:/gstore/logs
   virtuoso:
-    image: "openlink/virtuoso-opensource-7:latest"
+    image: "docker.io/openlink/virtuoso-opensource-7:latest"
     container_name: devenv_virtuoso
     environment:
       DBA_PASSWORD: "everyoneknows"

--- a/docs/guides/data-download-guide.md
+++ b/docs/guides/data-download-guide.md
@@ -240,7 +240,7 @@ version: '3.5'
 services:
 
   db:
-    image: tenforce/virtuoso
+    image: docker.io/tenforce/virtuoso
     ports:
       - 8895:8890
     volumes:
@@ -254,7 +254,7 @@ services:
   # and apply internal path as environment variable.
 
   databus_client:
-    image: dbpedia/databus-client:latest
+    image: docker.io/dbpedia/databus-client:latest
     environment:
       - SOURCE=/databus-client/query.sparql
       - ENDPOINT=https://dev.databus.dbpedia.org/sparql

--- a/docs/running-your-own-databus-server/https-and-proxy-setup.md
+++ b/docs/running-your-own-databus-server/https-and-proxy-setup.md
@@ -11,7 +11,7 @@ In the `.env` file the `DATABUS_PROXY_SERVER_ENABLE` needs to be set to `true` a
 ```
 services:
   databus:
-    image: "dbpedia/databus"
+    image: "docker.io/dbpedia/databus"
     ports:
   ... 
 #      - 80:80       # ** uncomment if proxy enabled only** HTTP port of included proxy (caddy) necessary for Auto-HTTPS via ACME and HTTP->HTTPS redirect

--- a/search/Dockerfile
+++ b/search/Dockerfile
@@ -1,4 +1,4 @@
-FROM tomcat:9.0.35-jdk11-openjdk
+FROM docker.io/tomcat:9.0.35-jdk11-openjdk
 
 COPY ./lookup-application.war /usr/local/tomcat/webapps/
 ENTRYPOINT [ "/usr/local/tomcat/bin/catalina.sh" ]


### PR DESCRIPTION
Specify the default container image registry docker.io, which is assumed by docker but not other container engines, like podman.
So this fix should allow that the Containerfiles and compose files work with other container engines as well.

This is a followup to #153 .