### PR TITLE
feat: customize 401 Unauthorized page with login prompt

### DIFF
--- a/public/js/components/error-notification/error-notifcation.js
+++ b/public/js/components/error-notification/error-notifcation.js
@@ -3,6 +3,8 @@ const { DatabusMsg } = require("../../utils/messages");
 function ErrorNotificationController() {
   var ctrl = this;
   ctrl.expanded = false;
+  ctrl.code = $ctrl.key;
+
 
   ctrl.toggleExpand = function () {
     ctrl.expanded = !ctrl.expanded;

--- a/public/js/components/error-notification/error-notification.html
+++ b/public/js/components/error-notification/error-notification.html
@@ -1,2 +1,11 @@
-<div ng-if="$ctrl.entity.hasError($ctrl.key)" class="error-tag">{{
-  $ctrl.get($ctrl.key) }}</div>
+<!-- custom 401 message -->
+<div ng-if="$ctrl.key == 401">
+  <h1>Welcome to private Databus</h1>
+  <p>You must log in to continue.</p>
+  <a href="/login">Click here to login</a>
+</div>
+
+<!-- fallback message -->
+<div ng-if="$ctrl.key != 401">
+  {{$ctrl.get($ctrl.key)}}
+</div>


### PR DESCRIPTION
This PR customizes the initial 401 Unauthorized page in private setups by adding a friendly login prompt.

- Shows message instead of empty 401
- Encourages user to login
- Includes link to /login
- Works only for 401
- No backend changes

Fixes #149


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added specialized error messaging for authentication failures, displaying a custom login prompt when unauthorized (401) errors occur.
  * Improved error display with targeted responses based on error type, with generic fallback messaging for other errors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->