### PR TITLE
Fix artifact title generation on client side

### DIFF
--- a/public/js/search/search-adapter.js
+++ b/public/js/search/search-adapter.js
@@ -5,7 +5,7 @@
 class SearchAdapter {
 
     static list = [
-        { 
+        {
             name: 'lookup',
             label: 'Lookup',
             factory: this.lookup
@@ -29,13 +29,19 @@ class SearchAdapter {
     static inferResourceTypes(docs) {
         // TODO:
     }
-    
+
 
     static lookup($http, endpoint) {
-        return new SearchAdapter($http, endpoint, function(query) {
+        return new SearchAdapter($http, endpoint, function (query) {
             return `?query=${query}&format=json`;
-        }, function(response) {
+        }, function (response) {
             var docs = response.data.docs;
+
+            docs.forEach(d => {
+                if (d.id && !d.title) {
+                    d.title = d.id.split("/")[1];
+                }
+            });
             SearchAdapter.inferResourceTypes(docs);
             return docs;
         });
@@ -53,7 +59,7 @@ class SearchAdapter {
         return virtuosoAdapter;
     }
 
-   
+
 
     async search(query) {
         try {

--- a/public/js/search/search-adapter.js
+++ b/public/js/search/search-adapter.js
@@ -39,9 +39,11 @@ class SearchAdapter {
 
             docs.forEach(d => {
                 if (d.id && !d.title) {
-                    d.title = d.id.split("/")[1];
+                    const parts = d.id.split("/").filter(Boolean);
+                    d.title = parts.length > 1 ? parts[parts.length - 1] : d.id;
                 }
             });
+
             SearchAdapter.inferResourceTypes(docs);
             return docs;
         });


### PR DESCRIPTION
Fixes #243

Normalize artifact titles on the client side so that version and content variant strings are not unintentionally included in the displayed title.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search result reliability by ensuring documents without titles display a sensible fallback title and by inferring resource types so results show clearer labels.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->