### PR TITLE
fix: resolve race condition and state accumulator in file browser

### DIFF
--- a/public/js/components/file-browser/file-browser.js
+++ b/public/js/components/file-browser/file-browser.js
@@ -155,7 +155,12 @@ function FileBrowserController($http, $scope) {
 
     } catch (e) {
       console.error(e);
-      ctrl.isLoading = false;
+      if (revision === ctrl.lastRequestRevision) {
+        ctrl.isLoading = false;
+        if (!ctrl.$scope.$root.$$phase) {
+          ctrl.$scope.$apply();
+        }
+      }
     }
   }
 

--- a/public/js/components/file-browser/file-browser.js
+++ b/public/js/components/file-browser/file-browser.js
@@ -105,55 +105,57 @@ function FileBrowserController($http, $scope) {
   ctrl.querySparql = async function (query) {
 
     ctrl.isLoading = true;
-    ctrl.totalSize = 0;
-    ctrl.numFiles = 0;
+    const revision = ++ctrl.lastRequestRevision;
 
     try {
-
-      var req = {
-        method: 'POST',
+      const req = {
+        method: "POST",
         url: DatabusConstants.DATABUS_SPARQL_ENDPOINT_URL,
         data: "format=json&query=" + encodeURIComponent(query),
         headers: {
           "Content-type": "application/x-www-form-urlencoded"
-        },
+        }
+      };
+
+      const updateResponse = await ctrl.$http(req);
+
+      if (revision !== ctrl.lastRequestRevision) {
+        return;
       }
 
-      var updateResponse = await ctrl.$http(req);
+      const bindings = updateResponse.data.results.bindings;
 
-      var data = updateResponse.data;
+      let totalSize = 0;
+      let numFiles = 0;
+      let uriList = "";
 
-      ctrl.isLoading = false;
+      for (const binding of bindings) {
+        binding.size.numericalValue = parseInt(binding.size.value, 10);
+        uriList += binding.file.value + "\n";
 
-
-      ctrl.queryResult.bindings = data.results.bindings;
-
-      ctrl.queryResult.uriList = "";
-
-      for (var b in ctrl.queryResult.bindings) {
-        var binding = ctrl.queryResult.bindings[b];
-        binding.size.numericalValue = parseInt(binding.size.value);
-        ctrl.queryResult.uriList += binding.file.value + "\n";
-
-        if (binding.variant != undefined) {
+        if (binding.variant) {
           binding.variant.value = ctrl.formatVariant(binding.variant.value);
         }
 
-
-
-
-        ctrl.totalSize += binding.size.numericalValue;
-        ctrl.numFiles++;
+        totalSize += binding.size.numericalValue;
+        numFiles++;
       }
 
-      ctrl.totalSize = ctrl.formatUploadSize(ctrl.totalSize);
+      ctrl.queryResult.bindings = bindings;
+      ctrl.queryResult.uriList = uriList;
 
-      if (!$scope.$root.$$phase) {
+      ctrl.totalSize = ctrl.formatUploadSize(totalSize);
+      ctrl.numFiles = numFiles;
+
+      ctrl.isLoading = false;
+
+      if (!ctrl.$scope.$root.$$phase) {
         ctrl.$scope.$apply();
       }
 
     } catch (e) {
-      console.log(e);
+      console.error(e);
+      ctrl.isLoading = false;
     }
   }
 


### PR DESCRIPTION
### Summary

This PR fixes issue #262 where switching between versions or content variants could cause the File Browser to display incorrect total size and file count values.

### Root Cause

Multiple SPARQL requests can finish out of order, allowing older responses to overwrite newer ones and display incorrect file counts and total size. This change also computes the totals using local variables before updating the UI state.

### Changes

* Introduce request revision with lastRequestRevision to ignore stale SPARQL responses.
* Calculate totalSize, numFiles, and uriList using local variables before updating the controller state.
* Update the UI only with the results of the most recent completed request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file browser search results to avoid outdated responses replacing newer ones.
  * Made result loading more reliable, with cleaner handling of loading state and errors.
  * Search results now better preserve file details, counts, and total size information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->