### PR TITLE
Fix: handle undefined binding.size to prevent NaN -fixes #262

### DIFF
--- a/public/js/components/file-browser/file-browser.js
+++ b/public/js/components/file-browser/file-browser.js
@@ -142,7 +142,7 @@ function FileBrowserController($http, $scope) {
 
 
 
-        ctrl.totalSize += binding.size.numericalValue;
+        ctrl.totalSize += binding.size?binding.size.numericalValue:0;
         ctrl.numFiles++;
       }
 

--- a/public/js/components/file-browser/file-browser.js
+++ b/public/js/components/file-browser/file-browser.js
@@ -132,7 +132,7 @@ function FileBrowserController($http, $scope) {
 
       for (var b in ctrl.queryResult.bindings) {
         var binding = ctrl.queryResult.bindings[b];
-        binding.size.numericalValue = parseInt(binding.size.value);
+        binding.size.numericalValue = binding.size? parseInt(binding.size.value):0;
         ctrl.queryResult.uriList += binding.file.value + "\n";
 
         if (binding.variant != undefined) {

--- a/public/js/components/file-browser/file-browser.js
+++ b/public/js/components/file-browser/file-browser.js
@@ -132,7 +132,7 @@ function FileBrowserController($http, $scope) {
 
       for (var b in ctrl.queryResult.bindings) {
         var binding = ctrl.queryResult.bindings[b];
-        binding.size.numericalValue = binding.size? parseInt(binding.size.value):0;
+        const sizeValue = binding.size? parseInt(binding.size.value):0;
         ctrl.queryResult.uriList += binding.file.value + "\n";
 
         if (binding.variant != undefined) {
@@ -142,7 +142,7 @@ function FileBrowserController($http, $scope) {
 
 
 
-        ctrl.totalSize += binding.size?binding.size.numericalValue:0;
+        ctrl.totalSize += sizeValue;
         ctrl.numFiles++;
       }
 


### PR DESCRIPTION
##Problem
When binding.size is undefined, totalSize becomes NaN, showing wrong file count and size in the UI.

##Fix
Added a null check to default to 0 if binding.size is undefined.

Fixes #262

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed file browser total size calculations to handle SPARQL results that may not include size data.
  * Missing size values now safely default to zero, preventing totals from failing or accumulating incorrect values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->