### PR TITLE
Fix #256: sort version dropdown list with ORDER BY DESC

### DIFF
--- a/server/app/common/queries/sparql/get-versions-by-account.sparql
+++ b/server/app/common/queries/sparql/get-versions-by-account.sparql
@@ -12,3 +12,4 @@ SELECT DISTINCT ?version WHERE
     ?version databus:account <%ACCOUNT_URI%> .
   }
 }
+ORDER BY DESC(?version)


### PR DESCRIPTION
Fixes #256

The SPARQL query that fetches versions for an account/group did not have an ORDER BY clause, so the version dropdown was returning results in arbitrary order instead of sorted by date.

Added ORDER BY DESC(?version) to server/app/common/queries/sparql/get-versions-by-account.sparql so the most recent version appears first.